### PR TITLE
Update filepicker-js patch version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
   ],
   "dependencies": {
     "angular": ">=1.2.0",
-    "filepicker-js": "2.3.1"
+    "filepicker-js": "2.3.4"
   }
 }


### PR DESCRIPTION
I was experiencing a bug with image conversions that the 2.3.4 filepicker-js patch fixed.

Bower currently gives a warning and makes me manually pick the version because filepicker-angular requires 2.3.1.
